### PR TITLE
Adding request and minimal test coverage

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,76 @@
+
+{
+  "esnext": true,
+  "disallowKeywords": ["with"],
+  "disallowKeywordsOnNewLine": ["else"],
+  "disallowMixedSpacesAndTabs": true,
+  "disallowMultipleLineStrings": true,
+  "disallowOperatorBeforeLineBreak": ["+", "."],
+  "disallowSpaceAfterObjectKeys": true,
+  "validateQuoteMarks": { "mark": "'", "escape": true },
+  "validateParameterSeparator": ", ",
+  "validateIndentation": 2,
+  "safeContextKeyword": ["self"],
+  "requireSpaceBetweenArguments": true,
+  "requireSpaceBeforeObjectValues": true,
+  "disallowSpaceAfterPrefixUnaryOperators": ["++", "--", "+", "-", "~", "!"],
+  "disallowSpaceBeforeBinaryOperators": [","],
+  "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
+  "disallowEmptyBlocks": true,
+  "disallowFunctionDeclarations": true,
+  "disallowMultipleVarDecl": true,
+  "disallowNewlineBeforeBlockStatements": true,
+  "requireLineBreakAfterVariableAssignment": true,
+  "requireCapitalizedConstructors": true,
+  "disallowYodaConditions": true,
+  "disallowMultipleSpaces": true,
+  "requireSpacesInsideObjectBrackets": "all",
+  "disallowSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInCallExpression": true,
+  "disallowSpacesInFunctionDeclaration": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInNamedFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInsideArrayBrackets": true,
+  "requireSpaceBeforeKeywords": [
+    "else",
+    "while",
+    "catch"
+  ],
+  "requireSemicolons": true,
+  "disallowSpacesInsideParentheses": true,
+  "disallowTrailingComma": true,
+  "disallowTrailingWhitespace": true,
+  "requireSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInFunction": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireCommaBeforeLineBreak": true,
+  "requireLineFeedAtFileEnd": true,
+  "requireSpaceAfterBinaryOperators": ["?", ":", "+", "-", "/", "*", "%", "==", "===", "!=", "!==", ">", ">=", "<", "<=", "&&", "||"],
+  "requireSpaceBeforeBinaryOperators": ["?", ":", "+", "-", "/", "*", "%", "==", "===", "!=", "!==", ">", ">=", "<", "<=", "&&", "||"],
+  "requireSpaceAfterKeywords": ["if", "else", "for", "while", "do", "switch", "return", "try", "catch"],
+  "requireSpaceBeforeKeywords": [
+    "else",
+    "while",
+    "catch"
+  ],
+  "requireSpaceBeforeBlockStatements": true,
+  "requireSpacesInConditionalExpression": {
+    "afterTest": true,
+    "beforeConsequent": true,
+    "afterConsequent": true,
+    "beforeAlternate": true
+  },
+  "requireSpacesInForStatement": true,
+  "requireSpacesInFunction": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "validateLineBreaks": "LF"
+}

--- a/mocha.opts
+++ b/mocha.opts
@@ -1,0 +1,2 @@
+--reporter spec
+--ui bdd

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "escher-suiteapi-js",
   "version": "1.1.0",
   "description": "Escher Suite Api js",
+  "scripts": {
+    "test": "NODE_ENV=test mocha $(find . -name \"*.spec.js\" -not -path \"./node_modules/*\")"
+  },
   "main": "request.js",
   "repository": {
     "type": "git",
@@ -20,6 +23,15 @@
     "bluebird": "^2.3.11",
     "escher-auth": "0.2.3",
     "lodash": "2.4.1",
-    "logentries-logformat": "git://github.com/emartech/logentries-logformat.git"
+    "logentries-logformat": "git://github.com/emartech/logentries-logformat.git",
+    "request": "^2.58.0"
+  },
+  "devDependencies": {
+    "chai": "^3.0.0",
+    "chai-as-promised": "^5.1.0",
+    "chai-subset": "^1.0.1",
+    "mocha": "^2.2.5",
+    "sinon": "^1.15.4",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,12 @@
   "version": "1.1.0",
   "description": "Escher Suite Api js",
   "scripts": {
-    "test": "NODE_ENV=test mocha $(find . -name \"*.spec.js\" -not -path \"./node_modules/*\")"
+    "test": "NODE_ENV=test mocha $(find . -name \"*.spec.js\" -not -path \"./node_modules/*\")",
+    "code-style": "jscs $(find . -name \"*.js\" -not -path \"./node_modules/*\")"
   },
+  "pre-commit": [
+    "code-style"
+  ],
   "main": "request.js",
   "repository": {
     "type": "git",
@@ -30,7 +34,9 @@
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",
     "chai-subset": "^1.0.1",
+    "jscs": "^1.13.1",
     "mocha": "^2.2.5",
+    "pre-commit": "^1.0.10",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.8.0"
   }

--- a/request.js
+++ b/request.js
@@ -1,6 +1,4 @@
 var Escher = require('escher-auth');
-var http = require('http');
-var https = require('https');
 var _ = require('lodash');
 var Options = require('./requestOption');
 var Wrapper = require('./wrapper');
@@ -60,7 +58,7 @@ SuiteRequest.prototype = {
 
 
   _getRequestFor: function(requestOptions, payload) {
-    var protocol = (this._options.secure) ? https : http;
+    var protocol = (this._options.secure) ? 'https:' : 'http:';
     return new Wrapper(requestOptions, protocol, payload);
   },
 

--- a/request.js
+++ b/request.js
@@ -65,7 +65,7 @@ SuiteRequest.prototype = {
 
   _getOptionsFor: function(type, path) {
     var defaultOptions = _.cloneDeep(this._options.toHash());
-    var realPath =  defaultOptions.prefix + path;
+    var realPath = defaultOptions.prefix + path;
 
     return _.merge(defaultOptions, {
       method: type,
@@ -89,7 +89,7 @@ SuiteRequest.prototype = {
 SuiteRequest.EscherConstants = {
   algoPrefix: 'EMS',
   vendorKey: 'EMS',
-  credentialScope:'eu/suite/ems_request',
+  credentialScope: 'eu/suite/ems_request',
   authHeaderName: 'X-Ems-Auth',
   dateHeaderName: 'X-Ems-Date'
 };

--- a/requestOption.js
+++ b/requestOption.js
@@ -5,7 +5,7 @@ var SuiteRequestOption = function(environment, options) {
   this.port = options.port || 443;
   this.host = environment;
   this.rejectUnauthorized = options.rejectUnauthorized !== false;
-  this.headers = [ ['content-type', 'application/json'] ];
+  this.headers = [['content-type', 'application/json']];
   this.prefix = '';
 
   if (!options) options = {};
@@ -52,11 +52,11 @@ SuiteRequestOption.createForInternalApi = function(environment, rejectUnauthoriz
   return CreateSuiteRequestOption('/api/v2/internal', environment, rejectUnauthorized);
 };
 
-SuiteRequestOption.createForServiceApi = function (environment, rejectUnauthorized) {
+SuiteRequestOption.createForServiceApi = function(environment, rejectUnauthorized) {
   return CreateSuiteRequestOption('/api/services', environment, rejectUnauthorized);
 };
 
-var CreateSuiteRequestOption = function (prefix, environment, rejectUnauthorized) {
+var CreateSuiteRequestOption = function(prefix, environment, rejectUnauthorized) {
   var options = {};
 
   if (typeof environment === 'object') {

--- a/testSetup.spec.js
+++ b/testSetup.spec.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var sinon = require('sinon');
+
+before(function() {
+  var chai = require('chai');
+  var sinonChai = require('sinon-chai');
+  var chaiSubset = require('chai-subset');
+  var chaiAsPromised = require('chai-as-promised');
+
+  chai.use(chaiAsPromised);
+  chai.use(chaiSubset);
+  chai.use(sinonChai);
+
+  sinon.stub.returnsWithResolve = function(data) {
+    return this.returns(Promise.resolve(data));
+  };
+
+  sinon.stub.returnsWithReject = function(error) {
+    return this.returns(Promise.reject(error));
+  };
+
+});
+
+
+beforeEach(function() {
+  this.sandbox = sinon.sandbox.create();
+});
+
+
+afterEach(function() {
+  this.sandbox.restore();
+});

--- a/wrapper.js
+++ b/wrapper.js
@@ -2,6 +2,7 @@ var Promise = require('bluebird');
 var SuiteRequestError = require('./requestError');
 var logger = require('logentries-logformat')('suiterequest');
 var _ = require('lodash');
+var request = require('request');
 
 
 var TIMEOUT_DELAY = 15000;
@@ -23,48 +24,51 @@ RequestWrapper.prototype = {
 
 
   _sendRequest: function(resolve, reject) {
-    var req = this.protocol.request(this.requestOptions, function(resp) {
-      var responseChunks = [];
+    var headers = {};
+    this.requestOptions.headers.forEach(function (header) {
+      headers[header[0]] = header[1];
+    });
 
-      resp.on('data', function(chunk) { responseChunks.push(chunk); });
+    var method = this.requestOptions.method.toLowerCase();
 
-      resp.on('end', function() {
-        if (!responseChunks.length) {
-          logger.error('server_error', 'empty response data');
-          return reject(new SuiteRequestError('Error in http response', 500, {}));
-        }
+    var reqOptions = {
+      uri: {
+        hostname: this.requestOptions.host,
+        port: this.requestOptions.port,
+        protocol: this.protocol + ':',
+        pathname: this.requestOptions.path
+      },
+      headers: headers,
+      timeout: TIMEOUT_DELAY
+    };
 
-        var data = JSON.parse(responseChunks.join(''));
-        if (resp.statusCode >= 400) {
-          logger.error('server_error', data.replyText, { code: resp.statusCode });
-          return reject(new SuiteRequestError('Error in http response', resp.statusCode, data));
-        }
+    if (this.payload) {
+      reqOptions.body = this.payload;
+    }
 
-        logger.success('send', this._getLogParameters());
-        return resolve({
-          statusCode: resp.statusCode,
-          data: data
+    request[method](reqOptions, function (err, response) {
+      if (err) {
+        logger.error('fatal_error', err.message);
+        return reject(new SuiteRequestError(err.message, 500));
+      }
+
+      if (!response.body) {
+        logger.error('server_error', 'empty response data');
+        return reject(new SuiteRequestError('Error in http response', 500, {}));
+      }
+
+      if (response.statusCode >= 400) {
+        logger.error('server_error', response.body.data.replyText, {
+          code: response.statusCode
         });
-      }.bind(this));
+        return reject(new SuiteRequestError('Error in http response', response.statusCode, response.body));
+      }
 
+      logger.success('send', this._getLogParameters());
+
+      return resolve(response);
     }.bind(this));
 
-    req.on('error', function(e) {
-      logger.error('fatal_error', e.message);
-      reject(new SuiteRequestError(e.message, 500));
-    });
-
-    req.on('socket', function(socket) {
-      socket.setTimeout(TIMEOUT_DELAY);
-
-      socket.on('timeout', function() {
-        logger.error('timeout', 'server timed out');
-        req.abort();
-      });
-    });
-
-    if (this.payload) req.write(this.payload);
-    req.end();
   },
 
 

--- a/wrapper.js
+++ b/wrapper.js
@@ -35,7 +35,7 @@ RequestWrapper.prototype = {
       uri: {
         hostname: this.requestOptions.host,
         port: this.requestOptions.port,
-        protocol: this.protocol + ':',
+        protocol: this.protocol,
         pathname: this.requestOptions.path
       },
       headers: headers,

--- a/wrapper.js
+++ b/wrapper.js
@@ -25,7 +25,7 @@ RequestWrapper.prototype = {
 
   _sendRequest: function(resolve, reject) {
     var headers = {};
-    this.requestOptions.headers.forEach(function (header) {
+    this.requestOptions.headers.forEach(function(header) {
       headers[header[0]] = header[1];
     });
 
@@ -46,7 +46,7 @@ RequestWrapper.prototype = {
       reqOptions.body = this.payload;
     }
 
-    request[method](reqOptions, function (err, response) {
+    request[method](reqOptions, function(err, response) {
       if (err) {
         logger.error('fatal_error', err.message);
         return reject(new SuiteRequestError(err.message, 500));

--- a/wrapper.spec.js
+++ b/wrapper.spec.js
@@ -1,0 +1,77 @@
+var Wrapper = require('./wrapper');
+var expect = require('chai').expect;
+var request = require('request');
+
+describe('Wrapper', function () {
+
+  it('creates a new wrapper instance', function () {
+
+    var requestOptions = {
+      data: 1
+    };
+
+    var protocol = {
+      request: function () {}
+    };
+
+    var payload = {
+      data: 2
+    };
+
+    var wrapper = new Wrapper(requestOptions, protocol, payload);
+
+    expect(wrapper).to.be.ok;
+    expect(wrapper.send).to.be.ok;
+
+    expect(wrapper.requestOptions).to.be.eql(requestOptions);
+    expect(wrapper.protocol).to.be.eql(protocol);
+    expect(wrapper.payload).to.be.eql(payload);
+
+  });
+
+  it('sends a GET new request', function (done) {
+
+    var requestOptions = {
+      port: 443,
+      host: 'very.host.io',
+      headers: [
+        ['content-type', 'very-format'],
+        ['x-custom', 'alma']
+      ],
+      method: 'GET',
+      path: '/purchases/1/content'
+    };
+
+    var apiRespone = {
+      body: 'data'
+    };
+
+    this.sandbox.stub(request, 'get', function (options, callback) {
+      expect(options).to.be.eql({
+        uri: {
+          hostname: requestOptions.host,
+          port: requestOptions.port,
+          protocol: 'http:',
+          pathname: requestOptions.path
+        },
+        headers: {
+          'content-type': 'very-format',
+          'x-custom': 'alma'
+        },
+        timeout: 15000
+      });
+      callback(null, apiRespone);
+    });
+
+    var protocol = 'http';
+
+    var wrapper = new Wrapper(requestOptions, protocol);
+
+    wrapper.send().then(function (response) {
+      expect(response).to.be.eql(apiRespone);
+      done();
+    }).catch(done);
+
+  });
+
+});

--- a/wrapper.spec.js
+++ b/wrapper.spec.js
@@ -10,9 +10,7 @@ describe('Wrapper', function () {
       data: 1
     };
 
-    var protocol = {
-      request: function () {}
-    };
+    var protocol = 'http:';
 
     var payload = {
       data: 2
@@ -63,7 +61,7 @@ describe('Wrapper', function () {
       callback(null, apiRespone);
     });
 
-    var protocol = 'http';
+    var protocol = 'http:';
 
     var wrapper = new Wrapper(requestOptions, protocol);
 

--- a/wrapper.spec.js
+++ b/wrapper.spec.js
@@ -2,9 +2,9 @@ var Wrapper = require('./wrapper');
 var expect = require('chai').expect;
 var request = require('request');
 
-describe('Wrapper', function () {
+describe('Wrapper', function() {
 
-  it('creates a new wrapper instance', function () {
+  it('creates a new wrapper instance', function() {
 
     var requestOptions = {
       data: 1
@@ -27,7 +27,7 @@ describe('Wrapper', function () {
 
   });
 
-  it('sends a GET new request', function (done) {
+  it('sends a GET new request', function(done) {
 
     var requestOptions = {
       port: 443,
@@ -44,7 +44,7 @@ describe('Wrapper', function () {
       body: 'data'
     };
 
-    this.sandbox.stub(request, 'get', function (options, callback) {
+    this.sandbox.stub(request, 'get', function(options, callback) {
       expect(options).to.be.eql({
         uri: {
           hostname: requestOptions.host,
@@ -65,7 +65,7 @@ describe('Wrapper', function () {
 
     var wrapper = new Wrapper(requestOptions, protocol);
 
-    wrapper.send().then(function (response) {
+    wrapper.send().then(function(response) {
       expect(response).to.be.eql(apiRespone);
       done();
     }).catch(done);


### PR DESCRIPTION
This change is required, so the v3 of the suite-js-sdk can return with a `http.IncomingMessage` instance.

The parsed body will be on `response.body`.

**Note: this is a breaking change, please release accordingly.**