### PR TITLE
fix(wrapper): allow body to be empty

### DIFF
--- a/requestOption.js
+++ b/requestOption.js
@@ -10,6 +10,7 @@ var SuiteRequestOption = function(environment, options) {
   this.headers = [['content-type', 'application/json'], ['host', environment]];
   this.prefix = '';
   this.timeout = 'timeout' in options ? options.timeout : 15000;
+  this.allowEmptyResponse = false;
 
   if (!options) {
     options = {};

--- a/requestOption.js
+++ b/requestOption.js
@@ -9,7 +9,7 @@ var SuiteRequestOption = function(environment, options) {
   this.rejectUnauthorized = options.rejectUnauthorized !== false;
   this.headers = [['content-type', 'application/json'], ['host', environment]];
   this.prefix = '';
-  this.timeout = options.timeout || 0;
+  this.timeout = 'timeout' in options ? options.timeout : 15000;
 
   if (!options) {
     options = {};

--- a/requestOption.spec.js
+++ b/requestOption.spec.js
@@ -45,18 +45,18 @@ describe('SuiteRequestOption', function() {
     it('should return a default value', function() {
       var requestOptions = new SuiteRequestOption(dummyServiceConfig.host, dummyServiceConfig);
 
-      expect(requestOptions.getTimeout()).to.be.eql(0);
+      expect(requestOptions.getTimeout()).to.be.eql(15000);
     });
 
     it('should return the timeout passed in the constructor', function() {
       var options = Object.assign({}, dummyServiceConfig);
-      options.timeout = 60000;
+      options.timeout = 0;
       var requestOptions = new SuiteRequestOption(dummyServiceConfig.host, options);
 
-      expect(requestOptions.getTimeout()).to.be.eql(60000);
+      expect(requestOptions.getTimeout()).to.be.eql(0);
     });
 
-    it('should return the timeout set', function() {
+    it('should return the timeout set by setTimeout', function() {
       var requestOptions = new SuiteRequestOption(dummyServiceConfig.host, dummyServiceConfig);
 
       requestOptions.setTimeout(60000);
@@ -80,7 +80,7 @@ describe('SuiteRequestOption', function() {
         port: 1234,
         prefix: '/api',
         rejectUnauthorized: false,
-        timeout: 0
+        timeout: 15000
       });
     });
 

--- a/requestOption.spec.js
+++ b/requestOption.spec.js
@@ -41,6 +41,21 @@ describe('SuiteRequestOption', function() {
 
   });
 
+  describe('allowEmptyResponse', function() {
+    it('should be set to false by default', function() {
+      var requestOptions = new SuiteRequestOption(dummyServiceConfig.host, dummyServiceConfig);
+
+      expect(requestOptions.allowEmptyResponse).to.eql(false);
+    });
+
+    it('should be set to the value provided in config', function() {
+      dummyServiceConfig.allowEmptyResponse = true;
+      var requestOptions = new SuiteRequestOption(dummyServiceConfig.host, dummyServiceConfig);
+
+      expect(requestOptions.allowEmptyResponse).to.eql(true);
+    });
+  });
+
   describe('timeout', function() {
     it('should return a default value', function() {
       var requestOptions = new SuiteRequestOption(dummyServiceConfig.host, dummyServiceConfig);

--- a/wrapper.js
+++ b/wrapper.js
@@ -61,11 +61,6 @@ RequestWrapper.prototype = {
         return reject(new SuiteRequestError(err.message, 500));
       }
 
-      if (!response.body) {
-        logger.error('server_error', 'empty response data');
-        return reject(new SuiteRequestError('Empty http response', 500));
-      }
-
       if (response.headers['content-type'] === 'application/json') {
         try {
           response.body = JSON.parse(response.body);

--- a/wrapper.js
+++ b/wrapper.js
@@ -58,6 +58,11 @@ RequestWrapper.prototype = {
         return reject(new SuiteRequestError(err.message, 500));
       }
 
+      if (!this.requestOptions.allowEmptyResponse && !response.body) {
+        logger.error('server_error', 'empty response data');
+        return reject(new SuiteRequestError('Empty http response', 500));
+      }
+
       if (response.headers['content-type'] === 'application/json') {
         try {
           response.body = JSON.parse(response.body);

--- a/wrapper.js
+++ b/wrapper.js
@@ -8,9 +8,6 @@ var _ = require('lodash');
 var request = require('request');
 var Timer = require('timer-machine');
 
-var DEFAULT_TIMEOUT = 15000;
-
-
 var RequestWrapper = function(requestOptions, protocol, payload) {
   this.requestOptions = requestOptions;
   this.protocol = protocol;
@@ -47,7 +44,7 @@ RequestWrapper.prototype = {
         pathname: this.requestOptions.path
       },
       headers: headers,
-      timeout: this.requestOptions.timeout || DEFAULT_TIMEOUT
+      timeout: this.requestOptions.timeout
     };
     debugLogger.log('wrapper_options', reqOptions);
 
@@ -96,7 +93,6 @@ RequestWrapper.prototype = {
   }
 
 };
-
 
 
 module.exports = RequestWrapper;

--- a/wrapper.spec.js
+++ b/wrapper.spec.js
@@ -110,16 +110,16 @@ describe('Wrapper', function() {
 
   describe('timeout', function() {
     it('should send GET request with given timeout in options', function*() {
-      var expectedRequestOption;
+      var actualRequestOption;
       this.sandbox.stub(request, 'get', function(options, callback) {
-        expectedRequestOption = options;
+        actualRequestOption = options;
         callback(null, apiResponse);
       });
 
       escherRequestOptions.timeout = 60000;
       yield (new Wrapper(escherRequestOptions, 'http:')).send();
 
-      expect(expectedRequestOption.timeout).to.be.eql(60000);
+      expect(actualRequestOption.timeout).to.be.eql(60000);
     });
   });
 });

--- a/wrapper.spec.js
+++ b/wrapper.spec.js
@@ -74,30 +74,32 @@ describe('Wrapper', function() {
       }
     });
 
-
-    it('should allow body to be empty', function *() {
-      apiResponse.headers['content-type'] = 'text/html';
-      apiResponse.body = '';
-      apiResponse.statusCode = 204;
-
-      var response = yield wrapper.send();
-
-      expect(response.statusCode).to.eql(204);
-    });
+    describe('when empty response is allowed', function() {
+      beforeEach(function() {
+        escherRequestOptions.allowEmptyResponse = true;
+        wrapper = new Wrapper(escherRequestOptions, 'http:');
+      });
 
 
-    [
-      { body: '', errorMessage: 'Unexpected end of JSON input' },
-      { body: 'this is an invalid json', errorMessage: 'Unexpected token h in JSON at position 1' }
-    ].forEach(function(testCase, index) {
-      it('should throw error if json is not parsable #' + index, function *() {
-        apiResponse.body = testCase.body;
+      it('should allow body to be empty', function *() {
+        apiResponse.headers['content-type'] = 'text/html';
+        apiResponse.body = '';
+        apiResponse.statusCode = 204;
+
+        var response = yield wrapper.send();
+
+        expect(response.statusCode).to.eql(204);
+      });
+
+
+      it('should throw error if json is not parsable (empty)', function *() {
+        apiResponse.body = '';
 
         try {
           yield wrapper.send();
         } catch (err) {
           expect(err).to.be.an.instanceof(SuiteRequestError);
-          expect(err.message).to.eql(testCase.errorMessage);
+          expect(err.message).to.eql('Unexpected end of JSON input');
           expect(err.code).to.eql(500);
           return;
         }
@@ -105,6 +107,36 @@ describe('Wrapper', function() {
       });
     });
 
+    describe('when empty response is not allowed', function() {
+      it('should throw error if response body is empty', function *() {
+        apiResponse.body = '';
+
+        try {
+          yield wrapper.send();
+        } catch (err) {
+          expect(err).to.be.an.instanceof(SuiteRequestError);
+          expect(err.message).to.eql('Empty http response');
+          expect(err.code).to.eql(500);
+          return;
+        }
+        throw new Error('Error should have been thrown');
+      });
+    });
+
+
+    it('should throw error if json is not parsable (malformed)', function *() {
+      apiResponse.body = 'this is an invalid json';
+
+      try {
+        yield wrapper.send();
+      } catch (err) {
+        expect(err).to.be.an.instanceof(SuiteRequestError);
+        expect(err.message).to.eql('Unexpected token h in JSON at position 1');
+        expect(err.code).to.eql(500);
+        return;
+      }
+      throw new Error('Error should have been thrown');
+    });
   });
 
 

--- a/wrapper.spec.js
+++ b/wrapper.spec.js
@@ -23,7 +23,8 @@ describe('Wrapper', function() {
         ['x-custom', 'alma']
       ],
       method: 'GET',
-      path: '/purchases/1/content'
+      path: '/purchases/1/content',
+      timeout: 15000
     };
 
     expectedRequestOptions = {
@@ -107,16 +108,18 @@ describe('Wrapper', function() {
   });
 
 
-  it('should send GET request with given timeout on options', function*() {
-    var expectedRequestOption;
-    this.sandbox.stub(request, 'get', function(options, callback) {
-      expectedRequestOption = options;
-      callback(null, apiResponse);
+  describe('timeout', function() {
+    it('should send GET request with given timeout in options', function*() {
+      var expectedRequestOption;
+      this.sandbox.stub(request, 'get', function(options, callback) {
+        expectedRequestOption = options;
+        callback(null, apiResponse);
+      });
+
+      escherRequestOptions.timeout = 60000;
+      yield (new Wrapper(escherRequestOptions, 'http:')).send();
+
+      expect(expectedRequestOption.timeout).to.be.eql(60000);
     });
-
-    escherRequestOptions.timeout = 60000;
-    yield (new Wrapper(escherRequestOptions, 'http:')).send();
-
-    expect(expectedRequestOption.timeout).to.be.eql(60000);
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: response without body (having only header) is still valid; So if you considered it invalid and build upon it, this change will break things for you.