### PR TITLE
feat(response handling): allow response body to be empty

### DIFF
--- a/requestOption.js
+++ b/requestOption.js
@@ -10,6 +10,7 @@ var SuiteRequestOption = function(environment, options) {
   this.headers = [['content-type', 'application/json'], ['host', environment]];
   this.prefix = '';
   this.timeout = 'timeout' in options ? options.timeout : 15000;
+  this.allowEmptyResponse = false;
 
   if (!options) {
     options = {};

--- a/requestOption.spec.js
+++ b/requestOption.spec.js
@@ -41,6 +41,21 @@ describe('SuiteRequestOption', function() {
 
   });
 
+  describe('allowEmptyResponse', function() {
+    it('should be set to false by default', function() {
+      var requestOptions = new SuiteRequestOption(dummyServiceConfig.host, dummyServiceConfig);
+
+      expect(requestOptions.allowEmptyResponse).to.eql(false);
+    });
+
+    it('should be set to the value provided in config', function() {
+      dummyServiceConfig.allowEmptyResponse = true;
+      var requestOptions = new SuiteRequestOption(dummyServiceConfig.host, dummyServiceConfig);
+
+      expect(requestOptions.allowEmptyResponse).to.eql(true);
+    });
+  });
+
   describe('timeout', function() {
     it('should return a default value', function() {
       var requestOptions = new SuiteRequestOption(dummyServiceConfig.host, dummyServiceConfig);

--- a/wrapper.js
+++ b/wrapper.js
@@ -58,7 +58,7 @@ RequestWrapper.prototype = {
         return reject(new SuiteRequestError(err.message, 500));
       }
 
-      if (!response.body) {
+      if (!this.requestOptions.allowEmptyResponse && !response.body) {
         logger.error('server_error', 'empty response data');
         return reject(new SuiteRequestError('Empty http response', 500));
       }


### PR DESCRIPTION
by default it works like before, but using the request option "allowEmptyResponse" it will allow the response's body to be empty