### PR TITLE
feat(error): for recoverable network errors return with 503 instead of 500

### DIFF
--- a/lib/requestError.js
+++ b/lib/requestError.js
@@ -1,10 +1,11 @@
 'use strict';
 
 class SuiteRequestError extends Error {
-  constructor(message, code, response) {
+  constructor(message, code, response, originalCode) {
     super(message);
 
     this.code = code;
+    this.originalCode = originalCode;
     this.name = 'SuiteRequestError';
 
     if (response) {

--- a/lib/requestError.spec.js
+++ b/lib/requestError.spec.js
@@ -15,7 +15,7 @@ describe('SuiteRequestError', function() {
         replyText: 'Too long',
         detailedMessage: 'Line too long'
       }
-    });
+    }, 'ECONNABORTED');
 
     expect(error.message).to.eql('Invalid request');
     expect(error.code).to.eql(400);
@@ -23,6 +23,7 @@ describe('SuiteRequestError', function() {
       replyText: 'Too long',
       detailedMessage: 'Line too long'
     });
+    expect(error.originalCode).to.eql('ECONNABORTED');
   });
 
   it('should store response as is when no data attribute present', function() {

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -74,7 +74,7 @@ class RequestWrapper {
     const recoverableErrorCodes = ['ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'ECONNABORTED'];
     const code = recoverableErrorCodes.includes(error.code) ? 503 : 500;
 
-    throw new SuiteRequestError(error.message, code, false, error.code);
+    throw new SuiteRequestError(error.message, code, {}, error.code);
   }
 
   _handleResponse(response) {

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -70,7 +70,11 @@ class RequestWrapper {
       logger.info('Canceled request');
     }
     logger.fromError('fatal_error', error, this._getLogParameters());
-    throw new SuiteRequestError(error.message, 500);
+
+    const recoverableErrorCodes = ['ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'ECONNABORTED'];
+    const code = recoverableErrorCodes.includes(error.code) ? 503 : 500;
+
+    throw new SuiteRequestError(error.message, code, false, error.code);
   }
 
   _handleResponse(response) {
@@ -145,7 +149,7 @@ class RequestWrapper {
       return JSON.parse(response.body);
     } catch (ex) {
       logger.fromError('fatal_error', ex, this._getLogParameters());
-      throw new SuiteRequestError(ex.message, 500);
+      throw new SuiteRequestError(ex.message, 500, response.body);
     }
   }
 }

--- a/lib/wrapper.js
+++ b/lib/wrapper.js
@@ -149,7 +149,7 @@ class RequestWrapper {
       return JSON.parse(response.body);
     } catch (ex) {
       logger.fromError('fatal_error', ex, this._getLogParameters());
-      throw new SuiteRequestError(ex.message, 500, response.body);
+      throw new SuiteRequestError(ex.message, 500);
     }
   }
 }

--- a/lib/wrapper.spec.js
+++ b/lib/wrapper.spec.js
@@ -257,7 +257,6 @@ describe('Wrapper', function() {
         expect(err).to.be.an.instanceof(SuiteRequestError);
         expect(err.message).to.match(/Unexpected token/);
         expect(err.code).to.eql(500);
-        expect(err.data).to.eql(apiResponse.data);
         return;
       }
       throw new Error('Error should have been thrown');

--- a/lib/wrapper.spec.js
+++ b/lib/wrapper.spec.js
@@ -192,9 +192,10 @@ describe('Wrapper', function() {
 
     describe('when there was an axios error', function() {
       let isCancel;
+      let axiosError;
 
       beforeEach(function() {
-        const axiosError = {
+        axiosError = {
           message: 'axios error message',
           stack: []
         };
@@ -232,6 +233,17 @@ describe('Wrapper', function() {
         });
       });
 
+      it('should pass original error code to SuiteRequestError', function*() {
+        try {
+          axiosError.code = 'ECONNABORTED';
+
+          yield wrapper.send();
+          throw new Error('should throw SuiteRequestError');
+        } catch (err) {
+          expect(err.originalCode).to.eql('ECONNABORTED');
+          expect(err.code).to.eql(503);
+        }
+      });
     });
 
 
@@ -244,6 +256,7 @@ describe('Wrapper', function() {
         expect(err).to.be.an.instanceof(SuiteRequestError);
         expect(err.message).to.match(/Unexpected token/);
         expect(err.code).to.eql(500);
+        expect(err.data).to.eql(apiResponse.data);
         return;
       }
       throw new Error('Error should have been thrown');

--- a/lib/wrapper.spec.js
+++ b/lib/wrapper.spec.js
@@ -242,6 +242,7 @@ describe('Wrapper', function() {
         } catch (err) {
           expect(err.originalCode).to.eql('ECONNABORTED');
           expect(err.code).to.eql(503);
+          expect(err.data).to.eql({});
         }
       });
     });


### PR DESCRIPTION
BREAKING CHANGE: previously code 500 errors can become 503 in recoverable cases