### PR TITLE
feat!: parse json error response

### DIFF
--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -155,8 +155,16 @@ export class RequestWrapper {
   }
 
   private isJsonResponse<T extends TransformedResponse | AxiosResponse>(response: T) {
-    return response.headers['content-type'] &&
-      response.headers['content-type'].indexOf('application/json') !== -1;
+    let headers: RawAxiosResponseHeaders | AxiosResponseHeaders = {};
+    Object.assign(headers, response.headers);
+    headers = Object.entries(response.headers)
+      .reduce((acc: RawAxiosResponseHeaders | AxiosResponseHeaders, [key, val]) => {
+        acc[key.toLowerCase()] = val.toLowerCase();
+        return acc;
+      }, ({}));
+
+    return headers['content-type'] &&
+      headers['content-type'].indexOf('application/json') !== -1;
   }
 
   private getLogParameters(extraParametersToLog = {}) {

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -109,10 +109,22 @@ export class RequestWrapper {
         code: error.response.status,
         reply_text: (error.response?.data || '')
       }));
+      let data = '';
+      if (error.response != null &&
+          this.isJsonResponse(error.response) &&
+            error.response.data != null &&
+            typeof error.response.data === 'string') {
+        try {
+          data = JSON.parse(error.response.data);
+        } catch (_) {
+          data = error.response.data;
+        }
+      }
+
       throw new EscherRequestError(
         'Error in http response (status: ' + error.response.status + ')',
         error.response.status,
-        (error.response?.data || '') as string
+        data
       );
     } else {
       if (!axios.isCancel(error)) {
@@ -142,7 +154,7 @@ export class RequestWrapper {
     };
   }
 
-  private isJsonResponse(response: TransformedResponse) {
+  private isJsonResponse<T extends TransformedResponse | AxiosResponse>(response: T) {
     return response.headers['content-type'] &&
       response.headers['content-type'].indexOf('application/json') !== -1;
   }

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -155,16 +155,8 @@ export class RequestWrapper {
   }
 
   private isJsonResponse<T extends TransformedResponse | AxiosResponse>(response: T) {
-    let headers: RawAxiosResponseHeaders | AxiosResponseHeaders = {};
-    Object.assign(headers, response.headers);
-    headers = Object.entries(response.headers)
-      .reduce((acc: RawAxiosResponseHeaders | AxiosResponseHeaders, [key, val]) => {
-        acc[key.toLowerCase()] = val.toLowerCase();
-        return acc;
-      }, ({}));
-
-    return headers['content-type'] &&
-      headers['content-type'].indexOf('application/json') !== -1;
+    return response.headers['content-type'] &&
+      response.headers['content-type'].indexOf('application/json') !== -1;
   }
 
   private getLogParameters(extraParametersToLog = {}) {


### PR DESCRIPTION
resolves: https://github.com/emartech/escher-suiteapi-js/issues/66

Signed-off-by: Boris Tomic <16724532+boristomic@users.noreply.github.com>

BREAKING CHANGE: Error response is parsed as JSON if response headers
have content-type application/json and if it's possible to parse the
data as JSON. Otherwise response will be retuned as string or default
response will be returned as empty string.
