### PR TITLE
chore: update axios to 1.7.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@emartech/json-logger": "7.2.3",
-    "axios": "1.7.5",
+    "axios": "1.7.9",
     "axios-retry": "3.4.0",
     "escher-auth": "3.2.4"
   },


### PR DESCRIPTION
Update axios to 1.7.9 because of Blackduck finding BDSA-2023-4213 (https://sap.blackducksoftware.com/api/components/31b73ea8-4b41-43ed-8ada-1d680a5ad50d/versions/bd286dcf-06ef-422d-86bf-b729a8d8061c/vulnerabilities?limit=100&offset=0&sort=overallScore%20DESC)