### PR TITLE
feat(deps): use version ranges for direct dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,10 @@
       "name": "@emartech/escher-request",
       "license": "MIT",
       "dependencies": {
-        "@emartech/json-logger": "7.2.3",
-        "axios": "1.7.9",
-        "axios-retry": "4.5.0",
-        "escher-auth": "3.2.4"
+        "@emartech/json-logger": "^7.2.3",
+        "axios": "~1.7.9",
+        "axios-retry": "^4.5.0",
+        "escher-auth": "^3.2.4"
       },
       "devDependencies": {
         "@types/chai": "4.3.11",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "@emartech/json-logger": "7.2.3",
-    "axios": "1.7.9",
-    "axios-retry": "4.5.0",
-    "escher-auth": "3.2.4"
+    "@emartech/json-logger": "^7.2.3",
+    "axios": "~1.7.9",
+    "axios-retry": "^4.5.0",
+    "escher-auth": "^3.2.4"
   },
   "devDependencies": {
     "@types/chai": "4.3.11",


### PR DESCRIPTION
A library shouldn't pin direct dependencies to allow consumers to upgrade to newer transient dependency versions, e.g. for security patches (see https://github.com/emartech/escher-suiteapi-js/pull/83).
Dev dependencies should continue to be pinned.

Since `axios` keeps releasing incompatible changes as part of minor releases, I used `~` for that and `^` for all others.

See also [Renovate Docs](https://docs.renovatebot.com/dependency-pinning/#ranges-for-libraries). Our Renovate config applies the same approach: https://github.com/emartech/escher-suiteapi-js/blob/498d19065131530c6e325b34077abf51c205030f/renovate.json#L6