### PR TITLE
chore(renovate): separate `axios` minor releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,12 +16,17 @@
   },
   "packageRules": [
     {
+      "groupName": "axios",
+      "matchPackageNames": ["axios"],
+      "matchUpdateTypes": ["minor"]
+    },
+    {
       "groupName": "typescript",
       "matchPackageNames": ["typescript"],
       "matchUpdateTypes": ["minor"]
     },
     {
-      "matchPackageNames": ["typescript"],
+      "matchPackageNames": ["axios", "typescript"],
       "separateMultipleMinor": true
     }
   ],


### PR DESCRIPTION
Related to #79 & #85.
As `axios` keeps releasing breaking changes as part of `minor` releases, this change separates those into dedicated PRs to enable better analysis of them.