### PR TITLE
fix(deps): increase minimum `@emartech/json-logger` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "@emartech/escher-request",
       "license": "MIT",
       "dependencies": {
-        "@emartech/json-logger": "^9.0.0",
+        "@emartech/json-logger": "^9.2.3",
         "axios": "^1.15.0",
         "axios-retry": "^4.5.0",
         "escher-auth": "^4.0.0"
@@ -137,12 +137,12 @@
       }
     },
     "node_modules/@emartech/json-logger": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@emartech/json-logger/-/json-logger-9.2.2.tgz",
-      "integrity": "sha512-ZSD/tvgfE1bvmGKr9hxvqfPdxgIgnC9K5CmC2IqCuEaG3F4K5D8yg1sEYXmqje6Zil/wax/BYjrLIHANiG2KvQ==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/@emartech/json-logger/-/json-logger-9.2.3.tgz",
+      "integrity": "sha512-2BFfkba5AUthiyTc5Ti8Usy/p/fByFEF557RAuCSC/s1YAK0s+Jhy4EbZQgkd4d1TtCH16RldNQyVBYP6vgTYA==",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.23"
+        "lodash": "^4.18.1"
       },
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@emartech/json-logger": "^9.0.0",
+    "@emartech/json-logger": "^9.2.3",
     "axios": "^1.15.0",
     "axios-retry": "^4.5.0",
     "escher-auth": "^4.0.0"


### PR DESCRIPTION
Include latest fixes for vulnerable dependency versions like `lodash`:
- https://github.com/emartech/json-logger-js/pull/114