### PR TITLE
fix(ci): fix cache key in GitHub actions workflow

### DIFF
--- a/.github/workflows/_init.yml
+++ b/.github/workflows/_init.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Get node cache key
         id: node-cache-key
-        run: echo ::set-output name=NODE_CACHE_KEY::npm-${{ steps.node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/package.json') }}
+        run: echo ::set-output name=NODE_CACHE_KEY::npm-${{ steps.node-version.outputs.NODE_VERSION }}-${{ hashFiles('**/.npmrc', '**/package*.json') }}
 
       - name: Cache dependencies
         id: cache-node-modules


### PR DESCRIPTION
Previously, only the `package.json` file was used to generate a hash as a cache key.
This meant that changes applied exclusively to `package-lock.json` would go undetected, causing CI to use an outdated cache.
Because of this, https://github.com/emartech/escher-request/pull/208 went green even though it actually breaks the build because of transitive typing changes.
The hash key should include `package-lock.json` as well.

Additionally, `.npmrc` has been included to account for any NPM configuration changes.