### PR TITLE
chore(renovate): bump dependency versions for vulnerability alerts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,9 @@
     "schedule": ["on the 1-7 day on Sunday"]
   },
   "schedule": ["on the 1-7 day on Sunday"],
+  "vulnerabilityAlerts": {
+    "rangeStrategy": "bump"
+  },
   "packageRules": [
     {
       "description": "Disable minimum release age for internal packages",


### PR DESCRIPTION
By default, Renovate uses [rangeStrategy=update-lockfile](https://docs.renovatebot.com/configuration-options/#rangestrategy) for [vulnerability alerts](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts).

However, I'd like to use [bump](https://docs.renovatebot.com/configuration-options/#rangestrategy) to ensure libraries update their version requirements so that downstream consumers automatically receive the vulnerability patches.
This results in our libraries being "secure by default", as they will always ensure that their own dependencies are patched.

Note: Unfortunately, this only works for direct dependencies and not for transitive vulnerabilities (because Renovate doesn't support transitive vulnerability remediation), but it's still better than nothing.